### PR TITLE
Implement configuration caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ Here is an example:
 
 ```json
 {
-  "schema": "iglu:com.snowplowanalytics.kinesis-tee/Config/avro/1-0-0",
+  "schema": "iglu:com.snowplowanalytics.kinesis-tee/Config/avro/1-1-0",
   "data": {
     "name": "My Kinesis Tee example",
+    "configCacheDurationSecs": 60,
     "targetStream": {
       "name": "my-target-stream",
     },

--- a/src/main/avro/com.snowplowanalytics.kinesistee.config/Configuration/avro/1-1-0.avsc
+++ b/src/main/avro/com.snowplowanalytics.kinesistee.config/Configuration/avro/1-1-0.avsc
@@ -8,6 +8,10 @@
          "type":"string"
       },
       {
+         "name":"configCacheDurationSecs",
+         "type":"int"
+      },
+      {
          "name":"targetStream",
          "type":{
             "name":"TargetStream",

--- a/src/main/scala/com/snowplowanalytics/kinesistee/Main.scala
+++ b/src/main/scala/com/snowplowanalytics/kinesistee/Main.scala
@@ -27,13 +27,13 @@ class Main {
 
   import Main._
 
+  private var configurationCache: Option[ConfigurationCache] = None
+
   val kinesisTee:Tee = KinesisTee
   val lambdaUtils:AwsLambdaUtils = LambdaUtils
   val configurationBuilder:Builder = ConfigurationBuilder
   val getKinesisConnector: (Region, Option[TargetAccount]) => AmazonKinesisClient = StreamWriter.buildClient
   val ddb: (AWSScalaRegion) => DynamoDB = DynamoDB.at
-
-  var configurationCache: Option[ConfigurationCache] = None
 
   /**
     * AWS Lambda entry point

--- a/src/test/resources/sample_self_describing_config.json
+++ b/src/test/resources/sample_self_describing_config.json
@@ -2,6 +2,7 @@
   "schema": "iglu:com.snowplowanalytics.kinesistee.tbd",
   "data": {
     "name": "My Kinesis Tee example",
+    "configCacheDurationSecs": 60,
     "targetStream": {
       "name": "my-target-stream",
       "targetAccount": null

--- a/src/test/resources/sample_with_target_acct.json
+++ b/src/test/resources/sample_with_target_acct.json
@@ -1,5 +1,6 @@
 {
   "name": "My Kinesis Tee example",
+  "configCacheDurationSecs": 60,
   "targetStream": {
     "name": "my-target-stream",
     "targetAccount": {

--- a/src/test/resources/sampleconfig.json
+++ b/src/test/resources/sampleconfig.json
@@ -1,5 +1,6 @@
 {
   "name": "My Kinesis Tee example",
+  "configCacheDurationSecs": 60,
   "targetStream": {
     "name": "my-target-stream",
     "targetAccount": null

--- a/src/test/scala/com/snowplowanalytics/kinesistee/MainSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/kinesistee/MainSpec.scala
@@ -39,6 +39,7 @@ import com.amazonaws.services.kinesis.AmazonKinesisClient
 class MainSpec extends Specification with Mockito {
 
   val sampleConfig = Configuration(name = "My Kinesis Tee example",
+                                   configCacheDurationSecs = 60,
                                    targetStream = TargetStream("my-target-stream", None),
                                    transformer = Some(Transformer(BuiltIn.SNOWPLOW_TO_NESTED_JSON)),
                                    filter = None)
@@ -255,6 +256,23 @@ class MainSpec extends Specification with Mockito {
       main.kinesisEventHandler(sampleKinesisEvent, sampleContext)
 
       there was one (main.lambdaUtils).getLambdaDescription(any[String], any[String])
+    }
+
+    "tee not caching configuration when cache duration is zero" in {
+      val configWithoutCache = sampleConfig.copy(configCacheDurationSecs = 0)
+
+      val main = new MockMain {
+        override val configurationBuilder:Builder = {
+          val builder = mock[Builder]
+          builder.build(any[String], any[String])(any[DynamoDB]) returns configWithoutCache
+          builder
+        }
+      }
+
+      main.kinesisEventHandler(sampleKinesisEvent, sampleContext)
+      main.kinesisEventHandler(sampleKinesisEvent, sampleContext)
+
+      there were two (main.lambdaUtils).getLambdaDescription(any[String], any[String])
     }
   }
 

--- a/src/test/scala/com/snowplowanalytics/kinesistee/MainSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/kinesistee/MainSpec.scala
@@ -247,6 +247,15 @@ class MainSpec extends Specification with Mockito {
                                           any[Option[FilterStrategy]],
                                           any[Seq[Content]])
     }
+
+    "tee caches configuration" in {
+      val main = new MockMain
+
+      main.kinesisEventHandler(sampleKinesisEvent, sampleContext)
+      main.kinesisEventHandler(sampleKinesisEvent, sampleContext)
+
+      there was one (main.lambdaUtils).getLambdaDescription(any[String], any[String])
+    }
   }
 
 }

--- a/src/test/scala/com/snowplowanalytics/kinesistee/config/ConfigurationBuilderSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/kinesistee/config/ConfigurationBuilderSpec.scala
@@ -68,8 +68,8 @@ class ConfigurationBuilderSpec extends Specification with Mockito {
       val items:util.List[java.util.Map[java.lang.String,com.amazonaws.services.dynamodbv2.model.AttributeValue]] = new util.ArrayList()
 
       val one:util.Map[String,com.amazonaws.services.dynamodbv2.model.AttributeValue] = new util.HashMap()
-      one.put("id", new AttributeValue(Some("with-id")))
-      one.put("configuration", new AttributeValue(Some(sampleGoodConfig)))
+      one.put("id", new AttributeValue(Some("with-id"), l = Nil))
+      one.put("configuration", new AttributeValue(Some(sampleGoodConfig), l = Nil))
       items.add(one)
 
       res.getItems returns items
@@ -95,8 +95,8 @@ class ConfigurationBuilderSpec extends Specification with Mockito {
       val items:util.List[java.util.Map[java.lang.String,com.amazonaws.services.dynamodbv2.model.AttributeValue]] = new util.ArrayList()
 
       val one:util.Map[String,com.amazonaws.services.dynamodbv2.model.AttributeValue] = new util.HashMap()
-      one.put("id", new AttributeValue(Some("with-id")))
-      one.put("this-is-not-config", new AttributeValue(Some("abc")))
+      one.put("id", new AttributeValue(Some("with-id"), l = Nil))
+      one.put("this-is-not-config", new AttributeValue(Some("abc"), l = Nil))
 
       items.add(one)
       res.getItems returns items

--- a/src/test/scala/com/snowplowanalytics/kinesistee/config/ConfigurationBuilderSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/kinesistee/config/ConfigurationBuilderSpec.scala
@@ -24,6 +24,7 @@ class ConfigurationBuilderSpec extends Specification with Mockito {
 
   val sampleGoodConfig = scala.io.Source.fromURL(getClass.getResource("/sample_self_describing_config.json")).mkString
   val sampleConfig = Configuration(name = "My Kinesis Tee example",
+                                   configCacheDurationSecs = 60,
                                    targetStream = TargetStream("my-target-stream", None),
                                    transformer = Some(Transformer(BuiltIn.SNOWPLOW_TO_NESTED_JSON)),
                                    filter = None)

--- a/src/test/scala/com/snowplowanalytics/kinesistee/config/KinesisTeeConfigSchemaSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/kinesistee/config/KinesisTeeConfigSchemaSpec.scala
@@ -39,6 +39,7 @@ class KinesisTeeConfigSchemaSpec extends Specification {
     result match {
       case scala.util.Failure(f) => ko(stackTrace(f))
       case scala.util.Success(s) => s mustEqual Configuration(name = "My Kinesis Tee example",
+                                                              configCacheDurationSecs = 60,
                                                               targetStream = TargetStream("my-target-stream", None),
                                                               transformer = Some(Transformer(BuiltIn.SNOWPLOW_TO_NESTED_JSON)),
                                                               filter = None)
@@ -53,6 +54,7 @@ class KinesisTeeConfigSchemaSpec extends Specification {
     result match {
       case scala.util.Failure(f) => ko(stackTrace(f))
       case scala.util.Success(s) => s mustEqual Configuration(name = "My Kinesis Tee example",
+        configCacheDurationSecs = 60,
         targetStream = TargetStream("my-target-stream", Some(TargetAccount("*", "*", "eu-west-1"))),
         transformer = Some(Transformer(BuiltIn.SNOWPLOW_TO_NESTED_JSON)),
         filter = None)


### PR DESCRIPTION
_Kinesis Lambda_ trigger will trigger _Lambda_ function at least once a second for each shard. 

_AWS Lambda_ API allows only very limited amount of requests per second. It throttles any excessive requests.

This _PR_ reduces number of _Lambda_ API calls and allows to run _Kinesis Tee_ with streams with more shards. The trade-off is that updates to the configuration done in _DynamoDB_ will be visible only after 1 minute.

It is achieved by caching _Lambda_ configuration for 60 seconds.

Please, let me know what do you think about it. I could also:
 1. make cache duration configurable
 2. cache only _Lambda_ function description instead of whole configuration. Only call to fetch _Lambda_ function description is problematic as a problem of configuration fetching can be solved by increasing _DynamoDB_ table capacity

This problem appeared for us when we run _KinesisTee_ on a stream with 16 shards.